### PR TITLE
fix: 修正第1章 AI编程工具演进时间线三处日期错误

### DIFF
--- a/en/Part-1-Foundations/01-The-New-Paradigm-of-Agent-Programming.md
+++ b/en/Part-1-Foundations/01-The-New-Paradigm-of-Agent-Programming.md
@@ -129,23 +129,23 @@ Before analyzing Claude Code's architecture, let's widen our perspective and loo
 ```mermaid
 flowchart TD
     A["2021.06 GitHub Copilot Technical Preview<br/>First LLM integration into editor"] -->
-    B["2022.12 ChatGPT Launch<br/>Proves LLM's general conversational ability"] -->
+    B["2022.11 ChatGPT Launch<br/>Proves LLM's general conversational ability"] -->
     C["2023.03 GPT-4 + Function Calling<br/>LLM transforms from text generator to instruction orchestrator"] -->
     D["2023.06 OpenAI Code Interpreter<br/>LLM gains code execution capability for the first time"] -->
     E["2023.11 Claude 2.1 + Tool Use<br/>200K context window"] -->
-    F["2024.01 Devin Launch<br/>First AI software engineer"] -->
+    F["2024.03 Devin Launch<br/>First AI software engineer"] -->
     G["2024.08 Cursor Agent Mode<br/>Editor-integrated Agent"] -->
     H["2024.10 Anthropic Computer Use<br/>LLM can operate GUI"] -->
+    J["2024.11 Anthropic Publishes MCP<br/>Standardized Agent communication protocol"] -->
     I["2025.02 Claude Code Launch<br/>Terminal-native Agent"] -->
-    J["2025.11 Anthropic Publishes MCP<br/>Standardized Agent communication protocol"] -->
     K["2026.03 Source Code Accidentally Exposed<br/>Community deeply examines Agent Harness"] -->
     L["Now ← You are here"]
 
     classDef event fill:#f0f7ff,stroke:#3b82f6,stroke-width:1px,color:#1e3a5f
     classDef milestone fill:#dbeafe,stroke:#2563eb,stroke-width:2px,color:#1e40af
     classDef current fill:#fef3c7,stroke:#f59e0b,stroke-width:2px,color:#92400e
-    class A,B,C,D,E,F,G,H event
-    class I,J,K milestone
+    class A,B,C,D,E,F,G,H,J event
+    class I,K milestone
     class L current
 ```
 

--- a/第一部分-基础篇/01-智能体编程的新范式.md
+++ b/第一部分-基础篇/01-智能体编程的新范式.md
@@ -129,23 +129,23 @@ flowchart TD
 ```mermaid
 flowchart TD
     A["2021.06 GitHub Copilot 技术预览<br/>首次将 LLM 集成到编辑器"] -->
-    B["2022.12 ChatGPT 发布<br/>证明 LLM 的通用对话能力"] -->
+    B["2022.11 ChatGPT 发布<br/>证明 LLM 的通用对话能力"] -->
     C["2023.03 GPT-4 + Function Calling<br/>LLM 从文本生成器变为指令编排器"] -->
     D["2023.06 OpenAI Code Interpreter<br/>LLM 首次获得代码执行能力"] -->
     E["2023.11 Claude 2.1 + Tool Use<br/>200K 上下文窗口"] -->
-    F["2024.01 Devin 发布<br/>第一个 AI 软件工程师"] -->
+    F["2024.03 Devin 发布<br/>第一个 AI 软件工程师"] -->
     G["2024.08 Cursor Agent 模式<br/>编辑器集成的 Agent"] -->
     H["2024.10 Anthropic Computer Use<br/>LLM 可以操作 GUI"] -->
+    J["2024.11 Anthropic 发布 MCP<br/>标准化 Agent 通信协议"] -->
     I["2025.02 Claude Code 发布<br/>终端原生 Agent"] -->
-    J["2025.11 Anthropic 发布 MCP<br/>标准化 Agent 通信协议"] -->
     K["2026.03 源码意外公开<br/>社区深入审视 Agent Harness"] -->
     L["现在 ← 你在这里"]
 
     classDef event fill:#f0f7ff,stroke:#3b82f6,stroke-width:1px,color:#1e3a5f
     classDef milestone fill:#dbeafe,stroke:#2563eb,stroke-width:2px,color:#1e40af
     classDef current fill:#fef3c7,stroke:#f59e0b,stroke-width:2px,color:#92400e
-    class A,B,C,D,E,F,G,H event
-    class I,J,K milestone
+    class A,B,C,D,E,F,G,H,J event
+    class I,K milestone
     class L current
 ```
 


### PR DESCRIPTION
## 修正内容

| # | 事件 | 错误 | 正确 | 一手源 |
|---|------|------|------|--------|
| 1 | ChatGPT | `2022.12` | **`2022.11`** | [OpenAI 官方博客](https://openai.com/index/chatgpt/) |
| 2 | Devin | `2024.01` | **`2024.03`** | [Cognition 官方推文](https://x.com/cognition/status/1767548763134964000) |
| 3 | MCP | `2025.11` | **`2024.11`** | [Anthropic 官方博客](https://www.anthropic.com/news/model-context-protocol) |

## 额外修正

MCP (2024.11) 在时间线链中的位置从 Claude Code (2025.02) 之后移到之前，恢复正确时序。

## 证据详情

### ChatGPT → 2022.11.30
- Sam Altman 推文: https://x.com/sama/status/1598038815599661056
  *"today we launched ChatGPT"* — Nov 30, 2022
- OpenAI 官方博客: https://openai.com/index/chatgpt/
- Wikipedia: "Release: November 30, 2022"

### Devin → 2024.03.12
- Cognition 官方推文: https://x.com/cognition/status/1767548763134964000
  *"Today we're excited to introduce Devin"* — Mar 12, 2024
- VentureBeat: Published 2024-03-12
  https://venturebeat.com/ai/cognition-emerges-from-stealth-to-launch-ai-software-engineer-devin/
- Bloomberg, PC Mag, Wired 同日报道一致确认

### MCP → 2024.11.25
- Anthropic 官方博客: https://www.anthropic.com/news/model-context-protocol
  页面标注 "Nov 25, 2024"
- Wikipedia 信息框: "Introduced: November 25, 2024"

## 影响文件
- `第一部分-基础篇/01-智能体编程的新范式.md`（中文）
- `en/Part-1-Foundations/01-The-New-Paradigm-of-Agent-Programming.md`（英文）